### PR TITLE
Set TELEGRAM_BRIDGE env var in Claude subprocess

### DIFF
--- a/src/claude-process.ts
+++ b/src/claude-process.ts
@@ -44,11 +44,14 @@ export class ClaudeProcess extends EventEmitter {
       {
         cwd: process.env.HOME || "/home/varant",
         stdio: ["pipe", "pipe", "pipe"],
-        env: Object.fromEntries(
-          Object.entries(process.env).filter(
-            ([k]) => !k.startsWith("CLAUDE") || k === "CLAUDE_API_KEY"
-          )
-        ),
+        env: {
+          ...Object.fromEntries(
+            Object.entries(process.env).filter(
+              ([k]) => !k.startsWith("CLAUDE") || k === "CLAUDE_API_KEY"
+            )
+          ),
+          TELEGRAM_BRIDGE: "1",
+        },
       }
     );
 


### PR DESCRIPTION
## Problem

When Claude Code runs as a subprocess of the Telegram bridge, it has no way to know it's being accessed via Telegram vs directly in a terminal. This matters because users may want Claude to behave differently depending on the interface — for example, identifying as a Telegram bot, adjusting tone, or enabling/disabling certain features.

## Solution

Pass `TELEGRAM_BRIDGE=1` as an environment variable to the Claude Code subprocess. This is a generic, project-agnostic name that any user of the bridge can check in their `CLAUDE.md` to configure conditional behavior.

For example, a user could add to their `CLAUDE.md`:
```
- If TELEGRAM_BRIDGE is set, you are a Telegram bot assistant
- If not set, you are Claude Code in the terminal
```

## Changes

- `src/claude-process.ts`: Added `TELEGRAM_BRIDGE: "1"` to the subprocess `env` object.

Previously this was named `CLANKY` (specific to one bot's name) — renamed to `TELEGRAM_BRIDGE` so it's useful for anyone using this project.

## Test plan

- [x] Start a session via Telegram — `echo $TELEGRAM_BRIDGE` returns `1`
- [x] Start a session directly in terminal — `TELEGRAM_BRIDGE` is not set
- [x] Claude correctly adjusts behavior based on the env var

cc @avarant

🤖 Generated with [Claude Code](https://claude.com/claude-code)