### PR TITLE
Set bot commands on startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -393,6 +393,14 @@ bot.catch((err) => {
 // --- Start ---
 async function main() {
   await permissionHandler.start();
+
+  // Set bot commands so Telegram's menu matches our actual commands
+  await bot.api.setMyCommands([
+    { command: "start", description: "Welcome & setup info" },
+    { command: "new", description: "Fresh session" },
+    { command: "id", description: "Show chat ID" },
+  ]);
+
   console.log("[bot] Starting Telegram bot...");
   bot.start({
     onStart: () => console.log("[bot] Bot is running!"),


### PR DESCRIPTION
## Summary
- Adds `setMyCommands` call on bot startup so the Telegram menu always shows the correct commands (`/start`, `/new`, `/id`)
- Prevents stale commands from a previous bot (OpenClaw) persisting in the menu

## Test plan
- [ ] Start the bridge and verify Telegram shows the correct 3 commands in the menu
- [ ] Verify `/start` shows "Welcome & setup info", `/new` shows "Fresh session", `/id` shows "Show chat ID"

cc @avarant

🤖 Generated with [Claude Code](https://claude.com/claude-code)